### PR TITLE
oss-fuzz: fix build.sh

### DIFF
--- a/tools/fuzz/oss-fuzz/build.sh
+++ b/tools/fuzz/oss-fuzz/build.sh
@@ -11,5 +11,5 @@ make clang=y -C tools/fuzz/x86_instruction_emulator libfuzzer-harness
 cp tools/fuzz/x86_instruction_emulator/libfuzzer-harness $OUT/x86_instruction_emulator
 
 # Runtime coverage collection requires access to source files and symlinks don't work
-cp xen/lib/x86/*.c tools/fuzz/x86_instruction_emulator
+cp xen/arch/x86/lib/cpu-policy/*.c tools/fuzz/x86_instruction_emulator
 cp tools/tests/x86_emulator/*.c tools/fuzz/x86_instruction_emulator


### PR DESCRIPTION
Updated the source file copy path for fuzzing.

Fixes the build error: https://oss-fuzz-build-logs.storage.googleapis.com/log-946eac68-f136-40ee-b4d6-4587402d5608.txt

```sh
...
fsanitize=address -fsanitize-address-use-after-scope -fsanitize=fuzzer-no-link -m64 -DBUILD_ID -fno-strict-aliasing -std=gnu99 -Wall -Wstrict-prototypes -Wno-unused-but-set-variable -Wno-unused-local-typedefs   -g3 -Werror -Og -fno-omit-frame-pointer -D__XEN_INTERFACE_VERSION__=__XEN_LATEST_INTERFACE_VERSION__ -MMD -MP -MF .libfuzzer-harness.d -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE   -I/src/xen/tools/fuzz/x86_instruction_emulator/../../../tools/include -D__XEN_TOOLS__ -iquote /src/xen/tools/fuzz/x86_instruction_emulator/../../../xen/arch/x86 -iquote ../../tests/x86_emulator -fsanitize=fuzzer -fsanitize=fuzzer -Wl,--wrap=fwrite -Wl,--wrap=memcmp -Wl,--wrap=memcpy -Wl,--wrap=memset -Wl,--wrap=printf -Wl,--wrap=putchar -Wl,--wrap=puts -Wl,--wrap=snprintf -Wl,--wrap=strstr -Wl,--wrap=vprintf -Wl,--wrap=vsnprintf fuzz-emul.o x86-emulate.o x86_emulate/0f01.o x86_emulate/0fae.o x86_emulate/0fc7.o x86_emulate/decode.o x86_emulate/fpu.o cpuid.o wrappers.o -o libfuzzer-harness
Step #3 - "compile-libfuzzer-address-x86_64": make: Leaving directory '/src/xen/tools/fuzz/x86_instruction_emulator'
Step #3 - "compile-libfuzzer-address-x86_64": cp: cannot stat 'xen/lib/x86/*.c': No such file or directory

```